### PR TITLE
Fix new npc sheet null ref

### DIFF
--- a/FabulaUltimaCampaignManager/Battle/battle_slot.tscn
+++ b/FabulaUltimaCampaignManager/Battle/battle_slot.tscn
@@ -69,6 +69,18 @@ tracks/1/keys = {
 "update": 0,
 "values": [0.0]
 }
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath(".:modulate")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
 
 [sub_resource type="Animation" id="Animation_iibqk"]
 resource_name = "active"
@@ -85,6 +97,18 @@ tracks/0/keys = {
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 0,
 "values": [-0.0174533, 0.0174533, -0.0174533, 0.0174533]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
 }
 
 [sub_resource type="Animation" id="Animation_cenu7"]
@@ -113,6 +137,18 @@ tracks/1/keys = {
 "transitions": PackedFloat32Array(1),
 "update": 0,
 "values": [0.0]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath(".:modulate")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 0.721569)]
 }
 
 [sub_resource type="Animation" id="Animation_axk60"]

--- a/FabulaUltimaCampaignManager/BeastiaryScenes/DescriptionImage.cs
+++ b/FabulaUltimaCampaignManager/BeastiaryScenes/DescriptionImage.cs
@@ -36,6 +36,6 @@ public partial class DescriptionImage : TextureRect, IBeastAttribute
         if (string.IsNullOrWhiteSpace(imageFileName)) return;
         imageFileName.CopyToResourceFolder(out var newPath);
         _beastTemplate.ImageFile = newPath;
-        BeastTemplateAction.Invoke(new HashSet<BeastEntryNode.Action> { BeastEntryNode.Action.CHANGED, BeastEntryNode.Action.SAVE });
+        BeastTemplateAction.Invoke(new HashSet<BeastEntryNode.Action> { BeastEntryNode.Action.CHANGED });
     }
 }

--- a/FabulaUltimaCampaignManager/BeastiaryScenes/NPCSheet/OtherActions/OtherActionDescriptionEdit.cs
+++ b/FabulaUltimaCampaignManager/BeastiaryScenes/NPCSheet/OtherActions/OtherActionDescriptionEdit.cs
@@ -2,7 +2,7 @@ using FabulaUltimaNpc;
 using FirstProject.Beastiary;
 using Godot;
 
-public partial class OtherActionDescriptionEdit : LineEdit
+public partial class OtherActionDescriptionEdit : TextEdit
 {
     private ActionTemplate _action;
 
@@ -13,8 +13,8 @@ public partial class OtherActionDescriptionEdit : LineEdit
     }
 
 
-    public void HandleTextChanged(string text)
+    public void HandleTextChanged()
     {
-        _action.Effect = text;
+        _action.Effect = Text;
     }
 }

--- a/FabulaUltimaCampaignManager/BeastiaryScenes/NPCSheet/OtherActions/other_action.tscn
+++ b/FabulaUltimaCampaignManager/BeastiaryScenes/NPCSheet/OtherActions/other_action.tscn
@@ -7,19 +7,24 @@
 [node name="OtherAction" type="VBoxContainer"]
 script = ExtResource("1_yf32p")
 
-[node name="ActionDescription" type="VFlowContainer" parent="."]
+[node name="ActionDescription" type="VBoxContainer" parent="."]
 layout_mode = 2
 
 [node name="ActionNameEdit" type="LineEdit" parent="ActionDescription"]
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
+size_flags_horizontal = 0
 placeholder_text = "Action Name"
 expand_to_text_length = true
 script = ExtResource("2_exa4m")
 
-[node name="DescriptionEdit" type="LineEdit" parent="ActionDescription"]
+[node name="DescriptionEdit" type="TextEdit" parent="ActionDescription"]
+custom_minimum_size = Vector2(200, 100)
 layout_mode = 2
+size_flags_vertical = 3
 placeholder_text = "Enter Description"
-expand_to_text_length = true
+wrap_mode = 1
+scroll_fit_content_height = true
 script = ExtResource("3_1due5")
 
 [node name="RemoveActionButton" type="Button" parent="."]

--- a/FabulaUltimaCampaignManager/BeastiaryScenes/NPCSheet/Skills/added_skill.tscn
+++ b/FabulaUltimaCampaignManager/BeastiaryScenes/NPCSheet/Skills/added_skill.tscn
@@ -36,8 +36,10 @@ script = ExtResource("4_ufr2p")
 
 [node name="SkillDescriptionTextEdit" type="TextEdit" parent="."]
 layout_mode = 2
+size_flags_vertical = 3
 placeholder_text = "Skill Description"
 editable = false
+wrap_mode = 1
 scroll_fit_content_height = true
 script = ExtResource("5_jxy4s")
 

--- a/FabulaUltimaCampaignManager/BeastiaryScenes/NPCSheet/Spells/added_spell.tscn
+++ b/FabulaUltimaCampaignManager/BeastiaryScenes/NPCSheet/Spells/added_spell.tscn
@@ -67,7 +67,10 @@ script = ExtResource("6_8o3ct")
 [node name="SpellTextEdit" type="TextEdit" parent="."]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
+size_flags_vertical = 3
 editable = false
+wrap_mode = 1
+scroll_fit_content_height = true
 script = ExtResource("7_8ixf4")
 
 [node name="RemoveSpellButton" type="Button" parent="."]

--- a/FabulaUltimaCampaignManager/Campaign/Equipment/EquipmentTypeOptionButton.cs
+++ b/FabulaUltimaCampaignManager/Campaign/Equipment/EquipmentTypeOptionButton.cs
@@ -1,11 +1,8 @@
-using FabulaUltimaNpc;
 using FirstProject;
 using FirstProject.Npc;
 using Godot;
-using Godot.Collections;
 using System;
 using System.Linq;
-using System.Reflection;
 
 public partial class EquipmentTypeOptionButton : OptionButton, INpcEquipmentReader
 {

--- a/FabulaUltimaCampaignManager/CampaignData/campaign_data.tres
+++ b/FabulaUltimaCampaignManager/CampaignData/campaign_data.tres
@@ -9,3 +9,4 @@ Encounters = null
 Id = "336b7d6a-10c5-4b69-a232-5b9f94e4a7b1"
 Players = null
 Equipment = null
+Villains = null

--- a/FabulaUltimaCampaignManager/Encounters/NpcStatWindow.cs
+++ b/FabulaUltimaCampaignManager/Encounters/NpcStatWindow.cs
@@ -1,4 +1,5 @@
 using FabulaUltimaNpc;
+using FirstProject.Npc;
 using Godot;
 using System;
 using System.Linq;
@@ -19,9 +20,10 @@ public partial class NpcStatWindow : Window
         this.ResizeForResolution();
     }
 
-	public void SetBeast(IBeastTemplate beast)
+	public void SetBeast(NpcInstance instance)
 	{     
-        _beastEntyNode.Beast = beast;        
+        _beastEntyNode.Beast = instance.Template;
+        Title = $"{instance.Model.Rank}: {instance.InstanceName}";
 	}
 
     public void OnCloseRequested()

--- a/FabulaUltimaCampaignManager/Encounters/ShowStats.cs
+++ b/FabulaUltimaCampaignManager/Encounters/ShowStats.cs
@@ -21,7 +21,7 @@ public partial class ShowStats : Button, INpcReader
         _statWindow = StatWindowScene.Instantiate<NpcStatWindow>();
         _statWindow.OnClose += OnClose;
         AddChild(_statWindow);
-        _statWindow.SetBeast(_npcInstance.Template);
+        _statWindow.SetBeast(_npcInstance);
         _statWindow.Show();
         this.Disabled = true;
     }

--- a/FabulaUltimaCampaignManager/configuration.tres
+++ b/FabulaUltimaCampaignManager/configuration.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://2biq1o4sj4tb"]
+[gd_resource type="Resource" load_steps=2 format=3]
 
 [ext_resource type="Script" path="res://Configuration.cs" id="1_d73sm"]
 
@@ -6,4 +6,4 @@
 script = ExtResource("1_d73sm")
 CampaignFolder = "user://campaignData/"
 DatabaseFilePath = "user://BeastiaryDB.sqlite"
-BackgroundMusicEnabled = false
+BackgroundMusicEnabled = true

--- a/FabulaUltimaDataImporter/FabulaUltimaDatabase/Instance.cs
+++ b/FabulaUltimaDataImporter/FabulaUltimaDatabase/Instance.cs
@@ -281,7 +281,7 @@ namespace FabulaUltimaDatabase
                         DamageMod = e.DamageMod.Value,
                         DamageType = damageTypes[e.DamageType.Value].ToDamageType(),
                         IsRanged = equipmentCategories[e.CategoryId.Value].IsRanged,
-                        AttackSkills = specialAttacks.Where(s => s.BasicAttackId == e.Id.Value).Select(s => skillMap[s.SkillId]).ToArray(),
+                        AttackSkills = specialAttacks.Where(s => s.BasicAttackId == e.Id.Value).Select(s => skillMap[s.SkillId]).ToList(),
                         IsEquipmentAttack = true,
                     } : null,
                     StatsModifier = equipmentCategories[e.CategoryId.Value].IsArmor ?
@@ -396,7 +396,7 @@ namespace FabulaUltimaDatabase
                     AccuracyMod = a.AttackMod,
                     DamageMod = a.DamageMod.Value,
                     IsRanged = a.IsRanged.Value,
-                    AttackSkills = specialAttacks.Where(s => s.BasicAttackId == a.Id.Value).Select(s => skillMap[s.SkillId]).ToArray()
+                    AttackSkills = specialAttacks.Where(s => s.BasicAttackId == a.Id.Value).Select(s => skillMap[s.SkillId]).ToList()
                 });
         }
 


### PR DESCRIPTION
- fix null reference error
- new npc spells, other actions and skills no longer force horizontal scrolling
- npc instance stats use said instances rank and name in the window title
- enemies go transparent when their turn is over